### PR TITLE
Add build phase management and framework handling capabilities

### DIFF
--- a/lib/src/pbx/build_phase.dart
+++ b/lib/src/pbx/build_phase.dart
@@ -24,7 +24,13 @@ mixin PBXCopyFilesBuildPhaseMixin on PBXBuildPhaseMixin {
 /// Element for the copy file build phase.
 class PBXCopyFilesBuildPhase = PBXBuildPhase with PBXCopyFilesBuildPhaseMixin;
 
-mixin PBXFrameworksBuildPhaseMixin on PBXBuildPhaseMixin {}
+mixin PBXFrameworksBuildPhaseMixin on PBXBuildPhaseMixin {
+  void linkBinaryWithFile(PBXFileReference file) {
+    var uuid = UuidGenerator().random();
+    project.set('objects/$uuid', {'isa': 'PBXBuildFile', 'fileRef': file.uuid});
+    project.set('$_path/files', [...getList('files'), uuid]);
+  }
+}
 
 /// Element for the framework link build phase.
 class PBXFrameworksBuildPhase = PBXBuildPhase with PBXFrameworksBuildPhaseMixin;

--- a/lib/src/pbx/build_phase.dart
+++ b/lib/src/pbx/build_phase.dart
@@ -51,6 +51,8 @@ mixin PBXShellScriptBuildPhaseMixin on PBXBuildPhaseMixin {
 
   /// The content of the script shell
   String get shellScript => get('shellScript');
+
+  String get name => get('name');
 }
 
 /// Element for the resources copy build phase.

--- a/lib/src/pbx/file_element.dart
+++ b/lib/src/pbx/file_element.dart
@@ -92,11 +92,11 @@ mixin PBXGroupMixin on PBXFileElement {
     return isRemoved;
   }
 
-  PBXFileReference? addReference(String path, {String sourceTree = '<group>'}) {
+  PBXFileReference? addReference(String path, {String sourceTree = '<group>', String? name}) {
     var uuid = UuidGenerator().random();
 
     project.set('objects/$uuid',
-        {'isa': 'PBXFileReference', 'path': path, 'sourceTree': sourceTree});
+        {'isa': 'PBXFileReference', 'path': path, 'name': name ?? path, 'sourceTree': sourceTree});
     project.set('$_path/children', [...getList('children'), uuid]);
 
     return project.getObject(uuid) as PBXFileReference?;

--- a/lib/src/pbx/file_element.dart
+++ b/lib/src/pbx/file_element.dart
@@ -92,14 +92,14 @@ mixin PBXGroupMixin on PBXFileElement {
     return isRemoved;
   }
 
-  PBXFileReference? addReference(String path, {String sourceTree = '<group>', String? name}) {
+  PBXFileReference addReference(String path, {String sourceTree = '<group>', String? name}) {
     var uuid = UuidGenerator().random();
+    name = name ?? path_lib.basename(path);
 
-    project.set('objects/$uuid',
-        {'isa': 'PBXFileReference', 'path': path, 'name': name ?? path, 'sourceTree': sourceTree});
+    project.set('objects/$uuid', {'isa': 'PBXFileReference', 'path': path, 'name': name, 'sourceTree': sourceTree});
     project.set('$_path/children', [...getList('children'), uuid]);
 
-    return project.getObject(uuid) as PBXFileReference?;
+    return project.getObject(uuid) as PBXFileReference;
   }
 }
 

--- a/lib/src/pbx/file_element.dart
+++ b/lib/src/pbx/file_element.dart
@@ -65,6 +65,33 @@ mixin PBXGroupMixin on PBXFileElement {
   /// A list of references to [PBXFileElement] elements
   List<PBXFileElement> get children => getObjectList('children');
 
+  bool removeReference(String path) {
+    var isRemoved = false;
+
+    var children = [...this.children];
+
+    // list uuids which is the same as 'path' parameter
+    final uuidToDeleted = children.where((e) => e.path == path).map((e) => e.uuid).toList();
+
+    if (uuidToDeleted.isNotEmpty) {
+      isRemoved = true;
+    }
+
+    // Remove object
+    children.removeWhere((childrenElement) => uuidToDeleted.any((element) => element == childrenElement.uuid));
+
+    for (var element in uuidToDeleted) {
+      project.set('objects/$element', null);
+    }
+
+    // Remove reference (UUID)
+    final modifiedChildrenUUIDList = children.map((e) => e.uuid).toList();
+    var p = '$_path/children';
+    project.set(p, [...modifiedChildrenUUIDList]);
+
+    return isRemoved;
+  }
+
   PBXFileReference? addReference(String path, {String sourceTree = '<group>'}) {
     var uuid = UuidGenerator().random();
 

--- a/lib/src/pbx/file_element.dart
+++ b/lib/src/pbx/file_element.dart
@@ -65,7 +65,7 @@ mixin PBXGroupMixin on PBXFileElement {
   /// A list of references to [PBXFileElement] elements
   List<PBXFileElement> get children => getObjectList('children');
 
-  bool removeReference(String path) {
+  bool removeReferences(String path) {
     var isRemoved = false;
 
     var children = [...this.children];

--- a/lib/src/pbx/target.dart
+++ b/lib/src/pbx/target.dart
@@ -83,6 +83,17 @@ mixin PBXTargetMixin on PBXElement {
 
     return isRemoved;
   }
+
+  void addFramework(String path, String sourceTree) {
+    var frameworks = project.groups.where((group) => group.name == 'Frameworks').single;
+
+    var reference = frameworks.children.where((file) => file.path == path);
+    if (reference.isEmpty) {
+      var file = frameworks.addReference(path, sourceTree: sourceTree);
+      var phase = buildPhases.where((phase) => phase.runtimeType == PBXFrameworksBuildPhase).single as PBXFrameworksBuildPhase;
+      phase.linkBinaryWithFile(file);
+    }
+  }
 }
 
 abstract class PBXTarget = PBXElement with PBXTargetMixin;

--- a/lib/src/pbx/target.dart
+++ b/lib/src/pbx/target.dart
@@ -56,6 +56,24 @@ mixin PBXTargetMixin on PBXElement {
     var p = 'objects/${this.uuid}/buildPhases';
     project.set(p, [...getList('buildPhases'), uuid]);
   }
+
+  /// Remove Run script from Xcode "Build Phase", also the reference.
+  void removeRunScript(String name) {
+    final buildPhasesListString = [...getList('buildPhases')];
+
+    // list uuid which is the same as 'name' parameter
+    final uuidToDeleted = buildPhases.whereType<PBXShellScriptBuildPhase>().where((element) => element.name == name).map((e) => e.uuid);
+
+    // Remove run script object (with all parameters)
+    for (final uuid in uuidToDeleted) {
+      buildPhasesListString.removeWhere((element) => (element as String) == uuid);
+      project.set('objects/$uuid', null);
+    }
+
+    // Remove UUIDs from buildPhases list (reference)
+    var p = 'objects/$uuid/buildPhases';
+    project.set(p, buildPhasesListString);
+  }
 }
 
 abstract class PBXTarget = PBXElement with PBXTargetMixin;

--- a/lib/src/pbx/target.dart
+++ b/lib/src/pbx/target.dart
@@ -27,9 +27,9 @@ mixin PBXTargetMixin on PBXElement {
     List<String> outputPaths = const [],
     List<String> outputFileListPaths = const [],
     String shellPath = '/bin/sh',
-    int? showEnvVarsInLog, // 'Show environment variables in build log' default checked (null - not visible)
+    bool showEnvVarsInLog = true, // 'Show environment variables in build log' default checked (null - not visible)
     String? dependencyFile, // Default 'discovered dependency file' option unchecked (null - not visible)
-    int? alwaysOutOfDate, // 'Based on dependency analysis' default checked (null - not visible)
+    bool alwaysOutOfDate = true, // 'Based on dependency analysis' default checked (null - not visible)
   }) {
     const buildActionMask = 2147483647; // buildActionMask is const (compatible) for this below parameter
     const runOnlyForDeploymentPostprocessing = 0; // install build only = false (unchecked)
@@ -39,7 +39,7 @@ mixin PBXTargetMixin on PBXElement {
     project.set('objects/$uuid', {
       'isa': 'PBXShellScriptBuildPhase',
       'name': name,
-      'alwaysOutOfDate': alwaysOutOfDate,
+      'alwaysOutOfDate': alwaysOutOfDate ? null : 1, // this is not an error, xCode set flag 1 if this value unchecked
       'buildActionMask': buildActionMask,
       'files': files,
       'inputFileListPaths': inputFileListPaths,
@@ -49,7 +49,7 @@ mixin PBXTargetMixin on PBXElement {
       'shellPath': shellPath,
       'shellScript': shellScript,
       'runOnlyForDeploymentPostprocessing': runOnlyForDeploymentPostprocessing,
-      'showEnvVarsInLog': showEnvVarsInLog,
+      'showEnvVarsInLog': showEnvVarsInLog ? null : 0, // this is not an error, xCode set flag 0 if this value unchecked
       'dependencyFile': dependencyFile,
     });
 

--- a/lib/src/pbx/target.dart
+++ b/lib/src/pbx/target.dart
@@ -26,6 +26,7 @@ mixin PBXTargetMixin on PBXElement {
     List<String> inputsPaths = const [],
     List<String> outputPaths = const [],
     List<String> outputFileListPaths = const [],
+    String shellPath = '/bin/sh',
     int? showEnvVarsInLog, // 'Show environment variables in build log' default checked (null - not visible)
     String? dependencyFile, // Default 'discovered dependency file' option unchecked (null - not visible)
     int? alwaysOutOfDate, // 'Based on dependency analysis' default checked (null - not visible)
@@ -45,7 +46,7 @@ mixin PBXTargetMixin on PBXElement {
       'inputPaths': inputsPaths,
       'outputFileListPaths': outputFileListPaths,
       'outputPaths': outputPaths,
-      'shellPath': '/bin/sh;',
+      'shellPath': shellPath,
       'shellScript': shellScript,
       'runOnlyForDeploymentPostprocessing': runOnlyForDeploymentPostprocessing,
       'showEnvVarsInLog': showEnvVarsInLog,

--- a/lib/src/pbx/target.dart
+++ b/lib/src/pbx/target.dart
@@ -57,12 +57,19 @@ mixin PBXTargetMixin on PBXElement {
     project.set(p, [...getList('buildPhases'), uuid]);
   }
 
-  /// Remove Run script from Xcode "Build Phase", also the reference.
-  void removeRunScript(String name) {
+  /// Remove Run script with proper [name] from Xcode "Build Phase", and also the reference.
+  /// Return true if script existed and now it doesn't, otherwise false.
+  bool removeRunScript(String name) {
+    var isRemoved = false;
+
     final buildPhasesListString = [...getList('buildPhases')];
 
     // list uuid which is the same as 'name' parameter
     final uuidToDeleted = buildPhases.whereType<PBXShellScriptBuildPhase>().where((element) => element.name == name).map((e) => e.uuid);
+
+    if (uuidToDeleted.isNotEmpty) {
+      isRemoved = true;
+    }
 
     // Remove run script object (with all parameters)
     for (final uuid in uuidToDeleted) {
@@ -73,6 +80,8 @@ mixin PBXTargetMixin on PBXElement {
     // Remove UUIDs from buildPhases list (reference)
     var p = 'objects/$uuid/buildPhases';
     project.set(p, buildPhasesListString);
+
+    return isRemoved;
   }
 }
 

--- a/lib/src/pbx/target.dart
+++ b/lib/src/pbx/target.dart
@@ -16,6 +16,45 @@ mixin PBXTargetMixin on PBXElement {
 
   /// The product name
   String get productName => get('productName');
+
+  /// Add Run script into Xcode "Build Phase".
+  void addRunScript({
+    required String name,
+    required String shellScript,
+    List<String> files = const [],
+    List<String> inputFileListPaths = const [],
+    List<String> inputsPaths = const [],
+    List<String> outputPaths = const [],
+    List<String> outputFileListPaths = const [],
+    int? showEnvVarsInLog, // 'Show environment variables in build log' default checked (null - not visible)
+    String? dependencyFile, // Default 'discovered dependency file' option unchecked (null - not visible)
+    int? alwaysOutOfDate, // 'Based on dependency analysis' default checked (null - not visible)
+  }) {
+    const buildActionMask = 2147483647; // buildActionMask is const (compatible) for this below parameter
+    const runOnlyForDeploymentPostprocessing = 0; // install build only = false (unchecked)
+
+    var uuid = UuidGenerator().random();
+
+    project.set('objects/$uuid', {
+      'isa': 'PBXShellScriptBuildPhase',
+      'name': name,
+      'alwaysOutOfDate': alwaysOutOfDate,
+      'buildActionMask': buildActionMask,
+      'files': files,
+      'inputFileListPaths': inputFileListPaths,
+      'inputPaths': inputsPaths,
+      'outputFileListPaths': outputFileListPaths,
+      'outputPaths': outputPaths,
+      'shellPath': '/bin/sh;',
+      'shellScript': shellScript,
+      'runOnlyForDeploymentPostprocessing': runOnlyForDeploymentPostprocessing,
+      'showEnvVarsInLog': showEnvVarsInLog,
+      'dependencyFile': dependencyFile,
+    });
+
+    var p = 'objects/${this.uuid}/buildPhases';
+    project.set(p, [...getList('buildPhases'), uuid]);
+  }
 }
 
 abstract class PBXTarget = PBXElement with PBXTargetMixin;


### PR DESCRIPTION
This PR adds functionality for programmatically managing Xcode build phases and frameworks. The changes enable developers to:
- Add and remove run script build phases
- Add frameworks to project targets
- Handle references with custom paths and source trees
- Fix iteration issues when modifying collections